### PR TITLE
Remove flash when change page in dark-mode

### DIFF
--- a/static/initialize-theme.js
+++ b/static/initialize-theme.js
@@ -1,0 +1,33 @@
+(function initializeTheme() {
+    syncBetweenTabs();
+    listenToOSChanges();
+}());
+
+// Listen to preference changes. The event only fires in inactive tabs, so theme changes aren't applied twice.
+function syncBetweenTabs() {
+    window.addEventListener('storage', (e) => {
+        if (e.key === 'preference-theme') {
+            if (e.newValue === 'light') {
+                enableTheme('light');
+            } else if (e.newValue === 'dark') {
+                enableTheme('dark');
+            }
+        }
+    })
+}
+
+// Add a listener in case OS-level preference changes.
+function listenToOSChanges() {
+    let mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+
+    mediaQueryList.addListener((m) => {
+        const root = document.documentElement;
+        if (m.matches !== true) {
+            if (!root.classList.contains('theme-light')) {
+                enableTheme('light');
+            }
+        } else if (!root.classList.contains('theme-dark')) {
+            enableTheme('dark');
+        }
+    })
+}

--- a/static/update-elements.js
+++ b/static/update-elements.js
@@ -1,40 +1,9 @@
-(function initializeTheme() {
-    syncBetweenTabs();
-    listenToOSChanges();
+(function updateElements() {
     let newTheme = returnThemeBasedOnLocalStorage()
         || returnThemeBasedOnOS()
         || returnThemeBasedOnTime();
     enableTheme(newTheme);
 }());
-
-// Listen to preference changes. The event only fires in inactive tabs, so theme changes aren't applied twice.
-function syncBetweenTabs() {
-    window.addEventListener('storage', (e) => {
-        if (e.key === 'preference-theme') {
-            if (e.newValue === 'light') {
-                enableTheme('light');
-            } else if (e.newValue === 'dark') {
-                enableTheme('dark');
-            }
-        }
-    })
-}
-
-// Add a listener in case OS-level preference changes.
-function listenToOSChanges() {
-    let mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
-
-    mediaQueryList.addListener((m) => {
-        const root = document.documentElement;
-        if (m.matches !== true) {
-            if (!root.classList.contains('theme-light')) {
-                enableTheme('light');
-            }
-        } else if (!root.classList.contains('theme-dark')) {
-            enableTheme('dark');
-        }
-    })
-}
 
 // If no preference was set, check what the OS pref is.
 function returnThemeBasedOnOS() {
@@ -89,11 +58,11 @@ function enableTheme(newTheme = 'light') {
 
     let button = document.getElementById('theme-' + otherTheme + '-button');
     button.classList.add('enabled');
-    button.setAttribute('aria-pressed', false);
+    button.setAttribute('aria-pressed', "false");
 
     button = document.getElementById('theme-' + newTheme + '-button');
     button.classList.remove('enabled');
-    button.setAttribute('aria-pressed', true);
+    button.setAttribute('aria-pressed', "true");
 
     gacelaLogoColor(newTheme);
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -31,7 +31,7 @@
   </script>
   {% endif %}
 
-  <script defer type="text/javascript" src="{{ get_url(path='themes.js') | safe }}"></script>
+  <script type="text/javascript" src="{{ get_url(path='initialize-theme.js') | safe }}"></script>
 </head>
 
 <body>
@@ -103,6 +103,7 @@
 </div>
 
 {% block js_body %}
+  <script type="text/javascript" src="{{ get_url(path='update-elements.js') | safe }}"></script>
 {% endblock js_body %}
 </body>
 </html>


### PR DESCRIPTION
## 📚 Description

Split the `js` files to load in the head the dark/white mode as the first thing to avoid white flashes when changing from A to B page.
